### PR TITLE
feat: add config entry for HTTPS redirection

### DIFF
--- a/Staat/Startup.cs
+++ b/Staat/Startup.cs
@@ -216,7 +216,10 @@ namespace Staat
                 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Staat v1"));
             }
 
-            app.UseHttpsRedirection();
+            if (bool.Parse(Configuration.GetSection("App")["RedirectToHttps"]))
+            {
+                app.UseHttpsRedirection();
+            }
 
             app.UseRouting();
 

--- a/Staat/appsettings.json
+++ b/Staat/appsettings.json
@@ -2,7 +2,8 @@
   "App": {
     "Url": "https://staat.localhost",
     "DatabaseType": "SQLSERVER",
-    "StorageString": "disk://path=C:\\inetpub\\Staat\\Storage"
+    "StorageString": "disk://path=C:\\inetpub\\Staat\\Storage",
+    "RedirectToHttps": false
   },
   "Email": {
     "Address": "no-reply@staat.tld",

--- a/docker/appsettings.json
+++ b/docker/appsettings.json
@@ -1,9 +1,9 @@
 {
   "App": {
-    "Url": "https://localhost",
-    "Secret": "i-am-very-secret",
+    "Url": "http://localhost",
     "DatabaseType": "SQLSERVER",
-    "StorageString": "disk://path=/var/storage"
+    "StorageString": "disk://path=/var/storage",
+    "RedirectToHttps": false
   },
   "Email": {
     "Address": "no-reply@staat.tld",
@@ -16,6 +16,11 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=staat_mssql_database;Initial Catalog=Staat_new;User Id=sa;Password=iAmRoot1234;MultipleActiveResultSets=true;"
+  },
+  "JwtBearer": {
+    "Secret": "i-am-very-secret",
+    "Issuer": "https://staat.localhost",
+    "Audience": "urn:staat-api"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
HTTPS redirection doesn't work inside the Docker container as it's not currently configured to forward HTTPS ports or to allow an SSL certificate to be passed.

Chances are that anyone using the Docker container will be doing so with a local reverse proxy through nginx or similar anyway, meaning that HTTPS isn't really needed.